### PR TITLE
Revert "Updating 'quickstart-kitchensink' image for overlay 'dev' with new image"

### DIFF
--- a/advanced/overlays/dev/kustomization.yml
+++ b/advanced/overlays/dev/kustomization.yml
@@ -23,7 +23,7 @@ images:
   #   newTag: latest
   - name: image-registry.openshift-image-registry.svc:5000/demo-7-dev/kitchensink:latest
     newName: image-registry.openshift-image-registry.svc:5000/kitchensink-cicd/kitchensink@sha256
-    newTag: 7b34a62331e169e82f01256c3297e40727a62637aa3aaf8bd9fdb734849187c7
+    newTag: 79a04f3b0096bc935b81553f56300c611acb8f88a567c6b2a8aef68137ca2a08
 patchesJson6902:
   - target:
       group: apps


### PR DESCRIPTION
Reverts atarazana/kitchensink-conf#8